### PR TITLE
Add GH CLI commands for transferring and archiving repos

### DIFF
--- a/justfile
+++ b/justfile
@@ -146,3 +146,20 @@ gh-all-prs:
     just --justfile {{justfile()}} gh-prs $project
     echo ""
   done
+
+# repo should be like: `owner/repo_name`
+[group('github')]
+gh-transfer repo new_owner:
+  #!/usr/bin/env bash
+  gh api \
+    --method POST \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    /repos/{{repo}}/transfer \
+    -f "new_owner={{new_owner}}"
+
+# repo should be like: `owner/repo_name`
+[group('github')]
+gh-archive repo:
+  #!/usr/bin/env bash
+  gh repo archive {{repo}} --yes


### PR DESCRIPTION
Adds `gh-transfer` and `gh-archive` commands. These should be useful for transitioning client projects from the command line. For transfers to work from the CLI, you need admin privileges in both orgs.

I just did this to efficiently transfer and archive 70+ repos from another org to ours using this script:

```bash
#! /bin/bash
gh repo list {owner} | awk '{print $1}' | while read repo; do
    echo "Transferring $repo..."
    just gh-transfer "$repo" thinknimble
    echo "Archiving $repo..."
    just gh-archive "$repo"
done

echo "Done."
```