### PR TITLE
added two commands one heroku and one gh

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ Note: For AWS helpers, the AWS CLI is required for these commands to work.
 
 - `tn gh-archive <repo>`: Archive a repository.
 
+- `tn gh-store-workflow repo include-prefix=true`: run the gh action for a repo to build google and testflight
+  - if this is a TN repo you can exclude the repo owner it will be appended automatically
+  - Otherwise provide the repo owner/org some-org/some-repo without the git part
+
+
 ### Heroku Commands
 
 - `tn heroku-create-pipeline <app_name> [team]`: Create a new Heroku pipeline with staging and production apps.
@@ -139,6 +144,10 @@ Note: For AWS helpers, the AWS CLI is required for these commands to work.
 - `tn heroku-delete-pipeline <pipeline> [force]`: Delete an entire Heroku pipeline and its apps.
   - Use force=true to skip confirmation prompt
   - Example: `tn heroku-delete-pipeline my-project true`
+
+- `tn heroku-promote2prod source to`: Promote an app from staging to prod using source (staging app) to (prod app)
+  - Example: `tn heroku-promote2prod some-staging some-production` you can also add multiple apps separated by a comma
+
 
 ## Contributing New Commands - aka "Recipes"
 

--- a/justfile
+++ b/justfile
@@ -205,7 +205,19 @@ gh-all-prs:
     echo ""
   done
 
-  # Ollama CLI
+# Build appstore builds for repo
+[group('github')]
+gh-store-workflow repo include-prefix='true':
+  #!/usr/bin/env bash
+  REPOSITORY={{repo}}
+  if [ {{include-prefix}} = "true" ]; then
+    REPOSITORY=thinknimble/{{repo}}
+  fi
+  echo "Storing workflows for $REPOSITORY..."
+  echo {{include-prefix}}
+  gh workflow run expo-teststore-build-ios.yml --repo $REPOSITORY && gh workflow run expo-teststore-build-android.yml --repo $REPOSITORY
+
+
 
 #
 # Ollama CLI
@@ -450,3 +462,9 @@ heroku-delete-pipeline pipeline force='false':
             echo "Aborted."
         fi
     fi
+
+
+[group('heroku')]
+heroku-promote2prod source to:
+    #!/usr/bin/env bash
+    heroku pipelines:promote -a {{source}} --to {{to}}


### PR DESCRIPTION
Because it seems we regularly fail to remember these TN commands enable promoting to production and running the build actions for repos. 